### PR TITLE
WDI-465/activities-page-backend

### DIFF
--- a/api/dbsetup.py
+++ b/api/dbsetup.py
@@ -178,21 +178,21 @@ if os.environ.get("POPULATE_DB"):
             qry = 'COPY "Users"(id, username, full_name, email, hashed_password, disabled, user_role_id) FROM STDIN WITH (FORMAT CSV, HEADER TRUE)'
             cursor.copy_expert(qry, f)
 
-        with open("api/data/testdata_meterobservations.csv", "r") as f:
-            qry = 'COPY "MeterObservations"(timestamp, value, notes, submitting_user_id, meter_id, observed_property_type_id, unit_id, location_id) FROM STDIN WITH (FORMAT CSV, HEADER TRUE)'
-            cursor.copy_expert(qry, f)
+        # with open("api/data/testdata_meterobservations.csv", "r") as f:
+        #     qry = 'COPY "MeterObservations"(timestamp, value, notes, submitting_user_id, meter_id, observed_property_type_id, unit_id, location_id) FROM STDIN WITH (FORMAT CSV, HEADER TRUE)'
+        #     cursor.copy_expert(qry, f)
 
-        with open("api/data/testdata_meteractivities.csv", "r") as f:
-            qry = 'COPY "MeterActivities"(id, timestamp_start, timestamp_end, notes, submitting_user_id, meter_id, activity_type_id, location_id) FROM STDIN WITH (FORMAT CSV, HEADER TRUE)'
-            cursor.copy_expert(qry, f)
+        # with open("api/data/testdata_meteractivities.csv", "r") as f:
+        #     qry = 'COPY "MeterActivities"(id, timestamp_start, timestamp_end, notes, submitting_user_id, meter_id, activity_type_id, location_id) FROM STDIN WITH (FORMAT CSV, HEADER TRUE)'
+        #     cursor.copy_expert(qry, f)
 
-        with open("api/data/testdata_partsused.csv", "r") as f:
-            qry = 'COPY "PartsUsed"(meter_activity_id, part_id, count) FROM STDIN WITH (FORMAT CSV, HEADER TRUE)'
-            cursor.copy_expert(qry, f)
+        # with open("api/data/testdata_partsused.csv", "r") as f:
+        #     qry = 'COPY "PartsUsed"(meter_activity_id, part_id, count) FROM STDIN WITH (FORMAT CSV, HEADER TRUE)'
+        #     cursor.copy_expert(qry, f)
 
     #Create geometries from location lat longs
     cursor.execute('update "Locations" set geom = ST_MakePoint(longitude,latitude)')
-    
+
     conn.commit()
     conn.close()
 

--- a/api/routes/activities.py
+++ b/api/routes/activities.py
@@ -8,7 +8,8 @@ from sqlalchemy import select
 
 from api.schemas.meter_schemas import (
     ObservedPropertyTypeLU,
-    MeterActivity
+    MeterActivity,
+    ActivityForm
 )
 from api.models.main_models import (
     Meters,
@@ -108,6 +109,32 @@ write_user = scoped_user(["read", "activities:write"])
 
 #     return form_options
 
+# Process a submitted activity
+# Returns 442 when one or more required fields of ActivityForm are not present
+# Returns the new MeterActivity on success
+@activity_router.post(
+    "/activities",
+    dependencies=[Depends(write_user)],
+    tags=["Activities"],
+)
+async def post_activity(activity_form: ActivityForm, db: Session = Depends(get_db)):
+
+    # for the recieved activity
+    # create MeterActivity
+    # add notes section info into Notes table and associate with MeterActivity id
+    # add used parts to PartsUsed table and associate with MeterActivity id
+
+    # for all observations
+    # turn into a MeterObservation by adding required fields
+
+    # if install
+    # associate meter with provided well id
+
+    # if uninstall
+    # associate meter with HQ location
+
+    print(activity_form.__dict__)
+    return db.scalars(select(MeterActivities).where(MeterActivities.id == 1)).first()
 
 @activity_router.get(
     "/activity_types",

--- a/api/routes/activities.py
+++ b/api/routes/activities.py
@@ -49,13 +49,10 @@ write_user = scoped_user(["read", "activities:write"])
 )
 async def post_activity(activity_form: ActivityForm, db: Session = Depends(get_db)):
 
-    # IF NOT UNINSTALL/INSTALL
-
     activity_meter = db.scalars(select(Meters).where(activity_form.activity_details.meter_id == Meters.id)).first()
     activity_well = db.scalars(select(Wells).where(activity_form.current_installation.well_id == Wells.id)).first()
     activity_type = db.scalars(select(ActivityTypeLU).where(activity_form.activity_details.activity_type_id == ActivityTypeLU.id)).first()
 
-    # If uninstalling
     if (activity_type.name == 'Uninstall'): # This needs to be a slug
         warehouse_status = db.scalars(select(MeterStatusLU).where(MeterStatusLU.status_name == 'Warehouse')).first()
         assumed_hq_location = db.scalars(select(Locations).where(Locations.type_id == 1)).first() # Probably needs a slug
@@ -63,12 +60,23 @@ async def post_activity(activity_form: ActivityForm, db: Session = Depends(get_d
         activity_meter.well_id = None
         activity_meter.status_id = warehouse_status.id
 
-    # If installing
     if (activity_type.name == 'Install'):
         installed_status = db.scalars(select(MeterStatusLU).where(MeterStatusLU.status_name == 'Installed')).first()
         activity_meter.well_id = activity_well.id
         activity_meter.location_id = activity_well.location.id
         activity_meter.status_id = installed_status.id
+
+    if(activity_type.name == 'Scrap'):
+        scrapped_status = db.scalars(select(MeterStatusLU).where(MeterStatusLU.status_name == 'Scrapped')).first()
+        activity_meter.well_id = None
+        activity_meter.location_id = None
+        activity_meter.status_id = scrapped_status.id
+
+    if(activity_type.name == 'Sell'):
+        sold_status = db.scalars(select(MeterStatusLU).where(MeterStatusLU.status_name == 'Sold')).first()
+        activity_meter.well_id = None
+        activity_meter.location_id = None
+        activity_meter.status_id = sold_status.id
 
     # Make updates to the meter based on user's entry in the current installation section
     if (activity_type.name != 'Uninstall'):
@@ -77,7 +85,7 @@ async def post_activity(activity_form: ActivityForm, db: Session = Depends(get_d
         activity_meter.well_distance_ft = activity_form.current_installation.well_distance_ft
         activity_meter.notes = activity_form.current_installation.notes
 
-    # Create and commit the meter activity
+    # Create the meter activity
     meter_activity = MeterActivities(
             timestamp_start = activity_form.activity_details.start_time,
             timestamp_end = activity_form.activity_details.end_time,
@@ -99,6 +107,8 @@ async def post_activity(activity_form: ActivityForm, db: Session = Depends(get_d
         db.add(note)
 
     # Create the working status note
+    # NOTE: The details section of the NoteTypeLU is being used as a slug (for now), 'working', 'not-working', and 'not-checked' are sent from the form
+    # And are checked for below to determine the correct working status note to use
     status_note_type = db.scalars(select(NoteTypeLU).where(NoteTypeLU.details == activity_form.notes.working_on_arrival)).first()
     note = Notes(meter_activity_id = meter_activity.id, note_type_id = status_note_type.id)
     db.add(note)

--- a/api/schemas/meter_schemas.py
+++ b/api/schemas/meter_schemas.py
@@ -84,6 +84,48 @@ class Meter(ORMBase):
     well: Optional[Well]
     location: Optional[Location]
 
+class ActivityForm(ORMBase):
+    """
+    The activity informaiton that is submitted by the frontend
+    """
+
+    class ActivityDetails(ORMBase):
+        meter_id: int
+        activity_type_id: int
+        user_id: int
+        date: datetime
+        start_time: datetime
+        end_time: datetime
+
+    class CurrentInstallation(ORMBase):
+        contact_name: Optional[str]
+        contact_phone: Optional[str]
+        well_id: Optional[int]
+        well_distance_ft: Optional[int]
+        notes: Optional[str]
+
+    class ObservationForm(ORMBase):
+        time: datetime
+        reading: int
+        property_type_id: int
+        unit_id: int
+
+    class MaintenanceRepair(ORMBase):
+        service_type_ids: Optional[List[int]]
+        description: Optional[str]
+
+    class Notes(ORMBase):
+        working_on_arrival: bool
+        selected_note_ids: Optional[List[int]]
+
+    activity_details: ActivityDetails
+    current_installation: CurrentInstallation
+    observations: Optional[List[ObservationForm]]
+    maintenance_repair: Optional[MaintenanceRepair]
+    notes: Notes
+    part_used_ids: Optional[List[int]]
+
+
 class Unit(ORMBase):
     """
     Describes Units

--- a/api/schemas/meter_schemas.py
+++ b/api/schemas/meter_schemas.py
@@ -115,7 +115,7 @@ class ActivityForm(ORMBase):
         description: Optional[str]
 
     class Notes(ORMBase):
-        working_on_arrival: bool
+        working_on_arrival: str
         selected_note_ids: Optional[List[int]]
 
     activity_details: ActivityDetails

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "dayjs": "^1.11.9",
         "immer": "^10.0.2",
         "leaflet": "^1.9.2",
+        "notistack": "^3.0.1",
         "plotly.js": "^2.16.3",
         "react": "^18.2.0",
         "react-auth-kit": "^2.7.1",
@@ -10787,6 +10788,14 @@
         "resolve": "^1.0.0"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.13.tgz",
+      "integrity": "sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -14893,6 +14902,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/notistack": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-3.0.1.tgz",
+      "integrity": "sha512-ntVZXXgSQH5WYfyU+3HfcXuKaapzAJ8fBLQ/G618rn3yvSzEbnOB8ZSOwhX+dAORy/lw+GC2N061JA0+gYWTVA==",
+      "dependencies": {
+        "clsx": "^1.1.0",
+        "goober": "^2.0.33"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/notistack"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -28835,6 +28865,12 @@
         "resolve": "^1.0.0"
       }
     },
+    "goober": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.13.tgz",
+      "integrity": "sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==",
+      "requires": {}
+    },
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -31604,6 +31640,15 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
+    },
+    "notistack": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-3.0.1.tgz",
+      "integrity": "sha512-ntVZXXgSQH5WYfyU+3HfcXuKaapzAJ8fBLQ/G618rn3yvSzEbnOB8ZSOwhX+dAORy/lw+GC2N061JA0+gYWTVA==",
+      "requires": {
+        "clsx": "^1.1.0",
+        "goober": "^2.0.33"
+      }
     },
     "npm-run-path": {
       "version": "4.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "dayjs": "^1.11.9",
     "immer": "^10.0.2",
     "leaflet": "^1.9.2",
+    "notistack": "^3.0.1",
     "plotly.js": "^2.16.3",
     "react": "^18.2.0",
     "react-auth-kit": "^2.7.1",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -18,11 +18,13 @@ import ActivityView from './views/Activities';
 import RequireScopes from './components/RequireScopes'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import { LocalizationProvider } from '@mui/x-date-pickers'
+import { SnackbarProvider } from 'notistack'
 
 function App() {
 
     return (
         <LocalizationProvider dateAdapter={AdapterDayjs}>
+        <SnackbarProvider anchorOrigin={{horizontal: 'right', vertical: 'bottom'}} maxSnack={10}>
         <AuthProvider
             authType = {'localstorage'}
             authName={'_auth'}
@@ -124,6 +126,7 @@ function App() {
                 </Routes>
             </Router>
         </AuthProvider>
+        </SnackbarProvider>
         </LocalizationProvider>
   );
 

--- a/frontend/src/interfaces.d.ts
+++ b/frontend/src/interfaces.d.ts
@@ -35,6 +35,23 @@ export interface ActivityForm {
     part_used_ids?: number[]
 }
 
+export interface MeterActivity {
+    id: int
+    timestamp_start: Date
+    timestamp_end: Date
+    notes?: string
+    submitting_user_id: int
+    meter_id: int
+    activity_type_id: int
+    location_id: int
+
+    submitting_user?: User
+    meter?: Meter
+    activity_type?: ActivityTypeLU
+    location?: Location
+    parts_used?: []
+}
+
 export interface ObservationForm {
     id: number // Just used for tracking them in the UI
     time: Dayjs

--- a/frontend/src/interfaces.d.ts
+++ b/frontend/src/interfaces.d.ts
@@ -28,7 +28,7 @@ export interface ActivityForm {
     }
 
     notes?: {
-        working_on_arrival: boolean
+        working_on_arrival: string
         selected_note_ids: number[]
     }
 

--- a/frontend/src/views/Activities/MeterActivityEntry/MeterActivityEntry.tsx
+++ b/frontend/src/views/Activities/MeterActivityEntry/MeterActivityEntry.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useState, useEffect, useRef } from 'react'
 import { Box, Button, Grid } from '@mui/material'
 import { useSnackbar } from 'notistack'
@@ -26,6 +27,7 @@ export default function MeterActivityEntry() {
     const [currentMeterStatus, setCurrentMeterStatus] = useState<string>()
     const [postRespData, postRespCode, postForm] = useApiPOST<MeterActivity | Error>('/activities')
 
+    const navigate = useNavigate()
     const activitySelectionRef = useRef<FormSubmitRef>()
     const installationRef = useRef<FormSubmitRef>()
     const observationRef = useRef<FormSubmitRef>()
@@ -43,15 +45,13 @@ export default function MeterActivityEntry() {
         partsRef.current?.onSubmit()
 
         postForm(activityForm.current)
-        //redirect to homepage
-
-        console.log(activityForm.current)
     }
 
     useDidMountEffect(() => {
         if (!postRespCode) return
         if(postRespCode == 200) {
             enqueueSnackbar('Successfully Submitted Activity!', {variant: 'success'})
+            navigate('/meters')
         }
         else if (postRespCode == 422) {
             enqueueSnackbar('One or More Required Fields Not Entered!', {variant: 'error'})

--- a/frontend/src/views/Activities/MeterActivityEntry/MeterActivitySelection.tsx
+++ b/frontend/src/views/Activities/MeterActivityEntry/MeterActivitySelection.tsx
@@ -19,6 +19,7 @@ import { gridBreakpoints } from '../ActivitiesView'
 import { useApiGET } from '../../../service/ApiService'
 import { Page, MeterListDTO, MeterListQueryParams, ActivityTypeLU, ActivityForm, SecurityScope } from '../../../interfaces'
 import { ActivityType } from '../../../enums'
+import { useSearchParams } from 'react-router-dom'
 
 interface MeterActivitySelectionProps {
     activityForm: React.MutableRefObject<ActivityForm>
@@ -85,6 +86,16 @@ export const MeterActivitySelection = forwardRef(({activityForm, setMeterID, act
 
     const authUser = useAuthUser()
     const hasAdminScope = authUser()?.user_role.security_scopes.map((scope: SecurityScope) => scope.scope_string).includes('admin')
+    const [searchParams] = useSearchParams()
+
+    // If search params are defined, use them to select the meter
+    useEffect(() => {
+        const meter_id = searchParams.get('meter_id')
+        const serial_number = searchParams.get('serial_number')
+        if (meter_id && serial_number) {
+            setSelectedMeter({id: parseInt(meter_id), serial_number: serial_number} as MeterListDTO)
+        }
+    }, [searchParams])
 
     // Meter ID is used by other components and must remain stateful
     useEffect(() => {
@@ -133,12 +144,12 @@ export const MeterActivitySelection = forwardRef(({activityForm, setMeterID, act
                     <Autocomplete
                         disableClearable
                         options={meterList.items}
-                        getOptionLabel={(op: MeterListDTO) => `${op.serial_number} (${op.status?.status_name})`}
+                        getOptionLabel={(op: MeterListDTO) => `${op.serial_number}` + (op.status ? `(${op.status?.status_name})` : '')}
                         onChange={(event: any, selectedMeter: MeterListDTO) => {setSelectedMeter(selectedMeter)}}
                         value={selectedMeter}
                         inputValue={meterSearchQuery}
                         onInputChange={(event: any, query: string) => {setMeterSearchQuery(query)}}
-                        isOptionEqualToValue={(a, b) => {return a.id == b.id}}
+                        isOptionEqualToValue={(a, b) => {return a?.id == b?.id}}
                         renderInput={(params: any) => <TextField {...params} size="small" label="Meter" placeholder="Begin typing to search" />}
                     />
                 </Grid>

--- a/frontend/src/views/Activities/MeterActivityEntry/NotesSelection.tsx
+++ b/frontend/src/views/Activities/MeterActivityEntry/NotesSelection.tsx
@@ -57,7 +57,7 @@ export const NotesSelection = forwardRef(({activityForm, meterID}: NotesSelectio
 
     function NoteToggleButton({note}: any) {
         return (
-            <Grid item xs={4}>
+            <Grid item xs={4} key={note.id}>
                 <ToggleButton
                     value="check"
                     color="primary"

--- a/frontend/src/views/Activities/MeterActivityEntry/NotesSelection.tsx
+++ b/frontend/src/views/Activities/MeterActivityEntry/NotesSelection.tsx
@@ -37,7 +37,7 @@ export const NotesSelection = forwardRef(({activityForm, meterID}: NotesSelectio
         }
     })
 
-    const [workingOnArrival, setWorkingOnArrival] = useState<boolean>(true)
+    const [workingOnArrival, setWorkingOnArrival] = useState<string>('not-checked')
     const [selectedNoteIDs, setSelectedNoteIDs] = useState<number[]>([]) // Notes toggled by the user
     const [visibleNoteIDs, setVisibleNoteIDs] = useState<number[]>([1, 2, 3]) // The default notes, and user-added ones from select dropdown
 
@@ -76,7 +76,7 @@ export const NotesSelection = forwardRef(({activityForm, meterID}: NotesSelectio
         <Box sx={{mt: 6}}>
             <h4>Notes</h4>
             <Grid container>
-                <Grid container item xs={12}>
+                <Grid container item {...gridBreakpoints} xs={12}>
 
                     {/* Is working on arrival boolean selection */}
                     <ToggleButtonGroup
@@ -85,10 +85,13 @@ export const NotesSelection = forwardRef(({activityForm, meterID}: NotesSelectio
                         color="primary"
                         exclusive>
 
-                        <ToggleButton value={true} sx={toggleStyle}>
+                        <ToggleButton value={'not-checked'} sx={toggleStyle}>
+                            Working Status Not Checked
+                        </ToggleButton>
+                        <ToggleButton value={'working'} sx={toggleStyle}>
                             Meter Working On Arrival
                         </ToggleButton>
-                        <ToggleButton value={false} sx={toggleStyle}>
+                        <ToggleButton value={'not-working'} sx={toggleStyle}>
                             Meter Not Working On Arrival
                         </ToggleButton>
                     </ToggleButtonGroup>
@@ -121,9 +124,9 @@ export const NotesSelection = forwardRef(({activityForm, meterID}: NotesSelectio
                                 }}
                             >
 
-                                {/*  List of notes not already visible */}
+                                {/*  List of notes not already visible, quick fix to exclude notes shown in the tri-state selection */}
                                 {notesList.map((nt: NoteTypeLU) => {
-                                    if(!visibleNoteIDs.some(x => x == nt.id)) {
+                                    if(!visibleNoteIDs.some(x => x == nt.id) && !['not-working', 'not-checked', 'working'].some(x => x == nt.details) ) {
                                         return <MenuItem key={nt.id} value={nt.id}>{nt.note}</MenuItem>
                                     }
                                 })}

--- a/frontend/src/views/Activities/MeterActivityEntry/ObservationsSelection.tsx
+++ b/frontend/src/views/Activities/MeterActivityEntry/ObservationsSelection.tsx
@@ -98,30 +98,6 @@ interface ObservationSelectionProps {
     activityForm: React.MutableRefObject<ActivityForm>
 }
 
-const defaultObservations: ObservationForm[] = [
-    {
-        id: 1,
-        time: dayjs(),
-        reading: '',
-        property_type_id: 2,
-        unit_id: 3
-    },
-    {
-        id: 2,
-        time: dayjs(),
-        reading: '',
-        property_type_id: 1,
-        unit_id: 1
-    },
-    {
-        id: 3,
-        time: dayjs(),
-        reading: '',
-        property_type_id: 1,
-        unit_id: 1
-    },
-]
-
 export const ObservationSelection = forwardRef(({activityForm}: ObservationSelectionProps, submitRef) => {
 
     // Exposed submit function to allow parent to request the form values
@@ -132,6 +108,30 @@ export const ObservationSelection = forwardRef(({activityForm}: ObservationSelec
             }
         }
     })
+
+    const defaultObservations: ObservationForm[] = [
+        {
+            id: 1,
+            time: dayjs(),
+            reading: '',
+            property_type_id: 2,
+            unit_id: 3
+        },
+        {
+            id: 2,
+            time: dayjs(),
+            reading: '',
+            property_type_id: 1,
+            unit_id: 1
+        },
+        {
+            id: 3,
+            time: dayjs(),
+            reading: '',
+            property_type_id: 1,
+            unit_id: 1
+        },
+    ]
 
     const [observations, setObservations] = useState<ObservationForm[]>(defaultObservations)
     const [currentObservationID, setCurrentObservationID] = useState<number>(defaultObservations.length + 1) // Track IDs to keep them unique

--- a/frontend/src/views/Activities/MeterActivityEntry/ObservationsSelection.tsx
+++ b/frontend/src/views/Activities/MeterActivityEntry/ObservationsSelection.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useState, forwardRef } from 'react'
 import { produce } from 'immer'
+import { useSnackbar } from 'notistack'
 
 import {
     Box,
@@ -31,7 +32,7 @@ interface ObservationRowProps {
 function ObservationRow({observation, setObservation, removeObservation, propertyTypes, units}: ObservationRowProps) {
 
     return (
-            <Grid container item xs={12} sx={{mb: 2}}>
+            <Grid container item xs={12} sx={{mb: 2}} key={observation.id}>
 
             {/*  Dont load until units and property types are loaded */}
             {(propertyTypes.length > 1 && units.length > 1) &&
@@ -137,6 +138,7 @@ export const ObservationSelection = forwardRef(({activityForm}: ObservationSelec
     const [numberOfObservations, setNumberOfObservations] = useState<number>(defaultObservations.length) // Track number of observations for dynamic button verbiage
     const [propertyTypes, setPropertyTypes] = useApiGET<ObservedPropertyTypeLU[]>('/observed_property_types', [])
     const [units, setUnits] = useApiGET<Unit[]>('/units', [])
+    const { enqueueSnackbar } = useSnackbar()
 
     // Functions to manage local list of observations, should ideally be impl as useReducer
     function addObservation() {

--- a/frontend/src/views/Activities/MeterActivityEntry/PartsSelection.tsx
+++ b/frontend/src/views/Activities/MeterActivityEntry/PartsSelection.tsx
@@ -69,7 +69,7 @@ export const PartsSelection = forwardRef(({activityForm, meterID}: PartsSelectio
 
     function PartToggleButton({pa}: {pa: PartAssociation}) {
         return (
-            <Grid item xs={4}>
+            <Grid item xs={4} key={pa.id}>
                 <ToggleButton
                     value="check"
                     color="primary"

--- a/frontend/src/views/Meters/MeterDetailsFields.tsx
+++ b/frontend/src/views/Meters/MeterDetailsFields.tsx
@@ -1,5 +1,6 @@
 import React, { ChangeEventHandler } from 'react'
 import { useState, useEffect } from 'react'
+import { useSnackbar } from 'notistack'
 
 import {
     Box,
@@ -165,6 +166,7 @@ export default function MeterDetailsFields({selectedMeterID}: MeterDetailsProps)
     const [meterDetailsQueryParams, setMeterDetailsQueryParams] = useState<MeterDetailsQueryParams>()
     const [meterDetails, setMeterDetails] = useApiGET<MeterDetails>('/meter', undefined, meterDetailsQueryParams, true)
     const [patchResponse, patchMeter] = useApiPATCH<MeterDetails>('/meter')
+    const { enqueueSnackbar } = useSnackbar()
 
     const authUser = useAuthUser()
     const hasAdminScope = authUser()?.user_role.security_scopes.map((scope: SecurityScope) => scope.scope_string).includes('admin')
@@ -174,6 +176,17 @@ export default function MeterDetailsFields({selectedMeterID}: MeterDetailsProps)
         if (selectedMeterID == undefined) return
         setMeterDetailsQueryParams({meter_id: selectedMeterID})
     }, [selectedMeterID])
+
+    useDidMountEffect(() => {
+        if (meterDetails == undefined) return
+
+        if(patchResponse instanceof Error) {
+            enqueueSnackbar('Meter Update Failed!', {variant: 'error'})
+        }
+        else {
+            enqueueSnackbar('Updated Meter!', {variant: 'success'})
+        }
+    }, [patchResponse])
 
     function onSaveMeterChanges() {
         patchMeter(meterDetails)

--- a/frontend/src/views/Meters/MeterDetailsFields.tsx
+++ b/frontend/src/views/Meters/MeterDetailsFields.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEventHandler } from 'react'
 import { useState, useEffect } from 'react'
 import { useSnackbar } from 'notistack'
+import { createSearchParams, useNavigate } from 'react-router-dom'
 
 import {
     Box,
@@ -167,6 +168,7 @@ export default function MeterDetailsFields({selectedMeterID}: MeterDetailsProps)
     const [meterDetails, setMeterDetails] = useApiGET<MeterDetails>('/meter', undefined, meterDetailsQueryParams, true)
     const [patchResponse, patchMeter] = useApiPATCH<MeterDetails>('/meter')
     const { enqueueSnackbar } = useSnackbar()
+    const navigate = useNavigate()
 
     const authUser = useAuthUser()
     const hasAdminScope = authUser()?.user_role.security_scopes.map((scope: SecurityScope) => scope.scope_string).includes('admin')
@@ -191,6 +193,17 @@ export default function MeterDetailsFields({selectedMeterID}: MeterDetailsProps)
     function onSaveMeterChanges() {
         patchMeter(meterDetails)
     }
+
+    function navigateToNewActivity() {
+        navigate({
+            pathname: '/activities',
+            search: createSearchParams({
+                meter_id: selectedMeterID?.toString() ?? '',
+                serial_number: meterDetails.serial_number ?? ''
+            }).toString()
+        })
+    }
+
     return (
             <Box>
                 <h3 style={{marginTop: 0}}>Selected Meter Details</h3>
@@ -343,7 +356,7 @@ export default function MeterDetailsFields({selectedMeterID}: MeterDetailsProps)
                             </Grid>
                         }
                         <Grid item >
-                            <Button type="submit" variant="contained" style={{}} onClick={() => {}} >New Activity</Button>
+                            <Button type="submit" variant="contained" style={{}} onClick={navigateToNewActivity} >New Activity</Button>
                         </Grid>
                         <Grid item >
                             <Button type="submit" variant="contained" style={{}} onClick={() => {}} >New Work Order</Button>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3612,7 +3612,7 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
-clsx@^1.2.1:
+clsx@^1.1.0, clsx@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
@@ -4177,7 +4177,7 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^3.0.2, csstype@^3.1.1:
+csstype@^3.0.10, csstype@^3.0.2, csstype@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz"
   integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
@@ -5888,6 +5888,11 @@ glslify@^7.0.0, glslify@^7.1.1:
     static-eval "^2.0.5"
     through2 "^2.0.1"
     xtend "^4.0.0"
+
+goober@^2.0.33:
+  version "2.1.13"
+  resolved "https://registry.npmjs.org/goober/-/goober-2.1.13.tgz"
+  integrity sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.10"
@@ -7744,6 +7749,14 @@ normalize-url@^6.0.1:
   resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
 
+notistack@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/notistack/-/notistack-3.0.1.tgz"
+  integrity sha512-ntVZXXgSQH5WYfyU+3HfcXuKaapzAJ8fBLQ/G618rn3yvSzEbnOB8ZSOwhX+dAORy/lw+GC2N061JA0+gYWTVA==
+  dependencies:
+    clsx "^1.1.0"
+    goober "^2.0.33"
+
 npm-run-path@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz"
@@ -9038,7 +9051,7 @@ react-dev-utils@^12.0.1:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-"react-dom@^17.0.0 || ^18.0.0", "react-dom@^17.0.2 || ^18.0.0", react-dom@^18.0.0, react-dom@^18.2.0, react-dom@>=16.6.0, react-dom@>=16.8, "react-dom@>=16.8.0 || ^17.x || ^18.x":
+"react-dom@^16.8.0 || ^17.0.0 || ^18.0.0", "react-dom@^17.0.0 || ^18.0.0", "react-dom@^17.0.2 || ^18.0.0", react-dom@^18.0.0, react-dom@^18.2.0, react-dom@>=16.6.0, react-dom@>=16.8, "react-dom@>=16.8.0 || ^17.x || ^18.x":
   version "18.2.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz"
   integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
@@ -9170,7 +9183,7 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-"react@^17.0.0 || ^18.0.0", "react@^17.0.2 || ^18.0.0", react@^18.0.0, react@^18.2.0, "react@>= 16", react@>=16.6.0, react@>=16.8, react@>=16.8.0, "react@>=16.8.0 || ^17.x || ^18.x", react@>0.13.0:
+"react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^17.0.0 || ^18.0.0", "react@^17.0.2 || ^18.0.0", react@^18.0.0, react@^18.2.0, "react@>= 16", react@>=16.6.0, react@>=16.8, react@>=16.8.0, "react@>=16.8.0 || ^17.x || ^18.x", react@>0.13.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==


### PR DESCRIPTION
The backend endpoint that receives the activities form. Includes some changes to the frontend also, see commit comments.

Notes: 
Must add in NoteTypeLUs based on the SQL script, Zach and Chris have the script and more detailed explanation.
Have to add in ServiceTypeLUs for any to show up on the form.
If you are using the seeded test observation and activity history, you need to update the id sequence for both in the DB.
ex: 'alter sequence "MeterActivities_id_seq" restart with 401'