### PR TITLE
Ose types endpoint

### DIFF
--- a/api/routes/OSE.py
+++ b/api/routes/OSE.py
@@ -523,6 +523,30 @@ def get_DB_types(db: Session = Depends(get_db)):
             activity_types
             )
         )
+    observed_property_types = list(
+        map(
+            lambda x: meter_schemas.DBTypesForOSE.GeneralTypeInfo(name=x.name,description=x.description), 
+            observed_property_types
+            )
+        )
+    service_types = list(
+        map(
+            lambda x: meter_schemas.DBTypesForOSE.GeneralTypeInfo(name=x.service_name,description=x.description), 
+            service_types
+            )
+        )
+    note_types = list(
+        map(
+            lambda x: meter_schemas.DBTypesForOSE.GeneralTypeInfo(name=x.note,description=x.details), 
+            note_types
+            )
+        )
+    meter_status_types = list(
+        map(
+            lambda x: meter_schemas.DBTypesForOSE.GeneralTypeInfo(name=x.status_name,description=x.description), 
+            meter_status_types
+            )
+        )
 
     # Create the response model
     response = meter_schemas.DBTypesForOSE(
@@ -532,4 +556,6 @@ def get_DB_types(db: Session = Depends(get_db)):
         note_types=note_types,
         meter_status_types=meter_status_types
     )
+
+    return response
     

--- a/api/routes/OSE.py
+++ b/api/routes/OSE.py
@@ -516,6 +516,14 @@ def get_DB_types(db: Session = Depends(get_db)):
     note_types = db.scalars(select(NoteTypeLU)).all()
     meter_status_types = db.scalars(select(MeterStatusLU)).all()
 
+    # Convert to 
+    activity_types = list(
+        map(
+            lambda x: meter_schemas.DBTypesForOSE.GeneralTypeInfo(name=x.name,description=x.description), 
+            activity_types
+            )
+        )
+
     # Create the response model
     response = meter_schemas.DBTypesForOSE(
         activity_types=activity_types,

--- a/api/routes/OSE.py
+++ b/api/routes/OSE.py
@@ -12,6 +12,11 @@ from api.models.main_models import (
     Wells,
     meterRegisters,
     workOrders,
+    ActivityTypeLU,
+    ObservedPropertyTypeLU,
+    ServiceTypeLU,
+    NoteTypeLU,
+    MeterStatusLU
 )
 
 from api.schemas import meter_schemas
@@ -494,3 +499,29 @@ def get_disapproval_response_by_request_id(
     )
 
     return response
+
+@ose_router.get(
+    "/get_DB_types",
+    tags=["OSE"],
+    response_model=meter_schemas.DBTypesForOSE
+)
+def get_DB_types(db: Session = Depends(get_db)):
+    '''
+    Return DB types from lookup tables
+    '''
+    # Load all the lookup tables
+    activity_types = db.scalars(select(ActivityTypeLU)).all()
+    observed_property_types = db.scalars(select(ObservedPropertyTypeLU)).all()
+    service_types = db.scalars(select(ServiceTypeLU)).all()
+    note_types = db.scalars(select(NoteTypeLU)).all()
+    meter_status_types = db.scalars(select(MeterStatusLU)).all()
+
+    # Create the response model
+    response = meter_schemas.DBTypesForOSE(
+        activity_types=activity_types,
+        observed_property_types=observed_property_types,
+        service_types=service_types,
+        note_types=note_types,
+        meter_status_types=meter_status_types
+    )
+    

--- a/api/schemas/meter_schemas.py
+++ b/api/schemas/meter_schemas.py
@@ -331,4 +331,18 @@ class PatchWorkOrder(BaseModel):
     notes: str | None = None
     creator: str | None = None
     assigned_user_id: int | None = None
+
+class DBTypesForOSE(BaseModel):
+    '''
+    Descriptions from the various look up tables that are relevant to the OSE.
+    '''
+    class GeneralTypeInfo(BaseModel):
+        name: str
+        description: str | None = None
+
+    activity_types: list[GeneralTypeInfo]
+    observed_property_types: list[GeneralTypeInfo]
+    service_types: list[GeneralTypeInfo]
+    note_types: list[GeneralTypeInfo]
+    meter_status_types: list[GeneralTypeInfo]
     


### PR DESCRIPTION
Added api endpoint so OSE can view different database "types". This is essentially the content of various lookup tables. Enables OSE to understand when a particular activity, observation, service, or note is entered.