### PR TITLE
Add /parts/used endpoint

### DIFF
--- a/api/routes/parts.py
+++ b/api/routes/parts.py
@@ -1,18 +1,22 @@
-from fastapi import Depends, APIRouter, HTTPException
+from fastapi import Depends, APIRouter, HTTPException, Query
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import select
 from typing import List
+from datetime import datetime
+import calendar
 
 from api.models.main_models import (
     Parts,
+    PartsUsed,
     PartAssociation,
     PartTypeLU,
     Meters,
     MeterTypeLU,
+    MeterActivities,
 )
 from api.schemas import part_schemas
 from api.session import get_db
-from api.route_util import _get, _patch
+from api.route_util import _get
 from api.enums import ScopedUser
 from sqlalchemy.exc import IntegrityError
 
@@ -27,6 +31,48 @@ part_router = APIRouter()
 )
 def get_parts(db: Session = Depends(get_db)):
     return db.scalars(select(Parts).options(joinedload(Parts.part_type))).all()
+
+
+@part_router.get(
+    "/parts/used",
+    tags=["Parts"],
+    dependencies=[Depends(ScopedUser.Read)],
+)
+def get_parts_used_within_range(
+    from_month: str = Query(..., pattern=r"^\d{4}-\d{2}$"),
+    to_month: str = Query(..., pattern=r"^\d{4}-\d{2}$"),
+    parts: List[int] = Query(...),
+    db: Session = Depends(get_db),
+):
+    try:
+        # Parse and normalize start of "from" month
+        from_date = datetime.strptime(from_month, "%Y-%m").replace(day=1)
+
+        # Determine end of "to" month
+        to_dt = datetime.strptime(to_month, "%Y-%m")
+        year, month = to_dt.year, to_dt.month
+        today = datetime.now()
+
+        if year == today.year and month == today.month:
+            to_date = today
+        else:
+            last_day = calendar.monthrange(year, month)[1]
+            to_date = to_dt.replace(day=last_day, hour=23, minute=59, second=59)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid date format. Use YYYY-MM.")
+
+    stmt = (
+        select(PartsUsed.c.meter_activity_id, PartsUsed.c.part_id)
+        .select_from(PartsUsed.join(MeterActivities))
+        .where(
+            MeterActivities.timestamp_start >= from_date,
+            MeterActivities.timestamp_start <= to_date,
+            PartsUsed.c.part_id.in_(parts)
+        )
+    )
+
+    rows = db.execute(stmt).all()
+    return [dict(row._mapping) for row in rows]
 
 
 @part_router.get(

--- a/api/routes/parts.py
+++ b/api/routes/parts.py
@@ -1,6 +1,6 @@
 from fastapi import Depends, APIRouter, HTTPException, Query
 from sqlalchemy.orm import Session, joinedload
-from sqlalchemy import select
+from sqlalchemy import select, func
 from typing import List
 from datetime import datetime
 import calendar
@@ -38,7 +38,7 @@ def get_parts(db: Session = Depends(get_db)):
     tags=["Parts"],
     dependencies=[Depends(ScopedUser.Read)],
 )
-def get_parts_used_within_range(
+def get_parts_used_summary(
     from_month: str = Query(..., pattern=r"^\d{4}-\d{2}$"),
     to_month: str = Query(..., pattern=r"^\d{4}-\d{2}$"),
     parts: List[int] = Query(...),
@@ -57,22 +57,63 @@ def get_parts_used_within_range(
             to_date = today
         else:
             last_day = calendar.monthrange(year, month)[1]
-            to_date = to_dt.replace(day=last_day, hour=23, minute=59, second=59)
+            to_date = to_dt.replace(
+                day=last_day,
+                hour=23,
+                minute=59,
+                second=59
+            )
     except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid date format. Use YYYY-MM.")
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid date format. Use YYYY-MM."
+        )
 
-    stmt = (
-        select(PartsUsed.c.meter_activity_id, PartsUsed.c.part_id)
-        .select_from(PartsUsed.join(MeterActivities))
-        .where(
+    usage_subq = (
+        db.query(
+            PartsUsed.c.part_id.label("used_part_id"),
+            func.count(PartsUsed.c.part_id).label("quantity")
+        )
+        .join(
+              MeterActivities,
+              MeterActivities.id == PartsUsed.c.meter_activity_id
+        )
+        .filter(
             MeterActivities.timestamp_start >= from_date,
             MeterActivities.timestamp_start <= to_date,
-            PartsUsed.c.part_id.in_(parts)
+            PartsUsed.c.part_id.in_(parts),
         )
+        .group_by(PartsUsed.c.part_id)
+        .subquery()
     )
 
-    rows = db.execute(stmt).all()
-    return [dict(row._mapping) for row in rows]
+    query = (
+        db.query(
+            Parts.id.label("id"),
+            Parts.part_number,
+            Parts.description,
+            Parts.price,
+            func.coalesce(usage_subq.c.quantity, 0).label("quantity")
+        )
+        .outerjoin(usage_subq, Parts.id == usage_subq.c.used_part_id)
+        .filter(Parts.id.in_(parts))
+        .order_by(Parts.part_number)
+    )
+
+    results = []
+    for row in query.all():
+        price = row.price or 0
+        total = price * row.quantity
+        results.append({
+            "id": row.id,
+            "part_number": row.part_number,
+            "description": row.description,
+            "price": price,
+            "quantity": row.quantity,
+            "total": total,
+        })
+
+    return results
 
 
 @part_router.get(

--- a/frontend/src/views/Reports/PartsUsed/index.tsx
+++ b/frontend/src/views/Reports/PartsUsed/index.tsx
@@ -83,7 +83,7 @@ export const PartsUsedReportView = () => {
 
   const authHeader = useAuthHeader();
   const partsQuery = useQuery<Part[]>({
-    queryKey: ["Inventory", "report", "parts"],
+    queryKey: ["Inventory", "report", "partslist"],
     queryFn: async () => {
       const response = await fetch(`${API_URL}/parts`, {
         headers: { Authorization: authHeader() },
@@ -95,6 +95,38 @@ export const PartsUsedReportView = () => {
     },
     staleTime: 1000 * 60 * 60 * 24, // 24 hours
     cacheTime: 1000 * 60 * 60 * 24, // cache in memory for 24 hours
+  });
+
+  const from = watch("from");
+  const to = watch("to");
+  const selectedPartIds = watch("parts") ?? [];
+
+  const partsUsedQuery = useQuery<any[]>({
+    queryKey: ["Inventory", "report", "partsused", from, to, selectedPartIds],
+    queryFn: async () => {
+      const searchParams = new URLSearchParams({
+        from_month: from?.format("YYYY-MM"),
+        to_month: to?.format("YYYY-MM"),
+      });
+
+      selectedPartIds.forEach((id: number) => {
+        searchParams.append("parts", id.toString());
+      });
+
+      const response = await fetch(
+        `${API_URL}/parts/used?${searchParams.toString()}`,
+        {
+          headers: { Authorization: authHeader() },
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch parts used data");
+      }
+
+      return response.json();
+    },
+    enabled: Boolean(from && to && selectedPartIds?.length > 0),
   });
 
   const selectedParts = (partsQuery?.data ?? []).filter((part) =>

--- a/frontend/src/views/Reports/PartsUsed/index.tsx
+++ b/frontend/src/views/Reports/PartsUsed/index.tsx
@@ -129,26 +129,12 @@ export const PartsUsedReportView = () => {
     enabled: Boolean(from && to && selectedPartIds?.length > 0),
   });
 
-  const selectedParts = (partsQuery?.data ?? []).filter((part) =>
-    watch("parts")?.includes(part.id),
-  );
-
   let runningTotal = 0;
 
-  const rows = selectedParts.map((part) => {
-    const unitPrice = part.price ?? 0;
-    const quantity = part.count ?? 0;
-    const total = quantity * unitPrice;
-
-    runningTotal += total;
-
+  const rows = partsUsedQuery?.data?.map((part) => {
+    runningTotal += part.total;
     return {
-      id: part.id,
-      part_number: part.part_number,
-      description: part.description,
-      price: unitPrice,
-      quantity,
-      total,
+      ...part,
       running_total: runningTotal,
     };
   });


### PR DESCRIPTION
## Functional Assumptions
1. Each Row in PartsUsed = 1 Unit Used
    * The table PartsUsed(meter_activity_id, part_id) acts as a many-to-many join where each row represents one usage of a part.
    * No separate quantity column is tracked per usage.
2. Current Price is Used for Total Calculations
    * The total cost per part is calculated as price * quantity using the current value of Parts.price
3. Date Range Filters Only Apply to MeterActivities timestamps
    * The filtering is based on MeterActivities.timestamp_start >= from_date and <= to_date.
4. The "from" and "to" Query Params are Inclusive
    * "from" month includes the first day of the month at 00:00
    * "to" month includes the last day of the month at 23:59:59, unless it's the current month, in which case it uses the current datetime as the end.